### PR TITLE
fix(deps): split invalid dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,6 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    groups:
-      all:
-        patterns:
-          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -30,10 +26,6 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    groups:
-      all:
-        patterns:
-          - "*"
 
   - package-ecosystem: "npm"
     directory: "/editors/vscode"
@@ -47,7 +39,8 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    groups:
-      all:
-        patterns:
-          - "*"
+    ignore:
+      - dependency-name: "@types/vscode"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
         run: |
           mkdir -p .tmp
           git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" > .tmp/changed-files.txt
-          go run ./scripts/check-vscode-changelog --file-list .tmp/changed-files.txt
+          go run ./scripts/check-vscode-changelog \
+            --file-list .tmp/changed-files.txt \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"
 
   lint-and-test:
     name: lint-and-test

--- a/scripts/check-vscode-changelog/main.go
+++ b/scripts/check-vscode-changelog/main.go
@@ -3,16 +3,26 @@ package main
 
 import (
 	"bufio"
+	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
+	"reflect"
+	"regexp"
+	"slices"
 	"strings"
 )
 
 type config struct {
 	FileList string
+	Base     string
+	Head     string
 }
+
+var commitSHAPattern = regexp.MustCompile(`^[a-f0-9]{40}$`)
 
 func main() {
 	if err := run(); err != nil {
@@ -30,7 +40,10 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	required, reasons := changelogRequired(files)
+	required, reasons, err := changelogRequired(cfg, files)
+	if err != nil {
+		return err
+	}
 	if !required {
 		return nil
 	}
@@ -40,6 +53,8 @@ func run() error {
 func parseFlags() (config, error) {
 	var cfg config
 	flag.StringVar(&cfg.FileList, "file-list", "", "Path to newline-delimited changed files list")
+	flag.StringVar(&cfg.Base, "base", "", "Base git ref for pull request comparison")
+	flag.StringVar(&cfg.Head, "head", "", "Head git ref for pull request comparison")
 	flag.Parse()
 	if strings.TrimSpace(cfg.FileList) == "" {
 		return config{}, errors.New("required flag: --file-list")
@@ -67,7 +82,7 @@ func readFiles(path string) ([]string, error) {
 	return files, nil
 }
 
-func changelogRequired(files []string) (bool, []string) {
+func changelogRequired(cfg config, files []string) (bool, []string, error) {
 	hasChangelog := false
 	var reasons []string
 	for _, file := range files {
@@ -79,7 +94,31 @@ func changelogRequired(files []string) (bool, []string) {
 			reasons = append(reasons, file)
 		}
 	}
-	return len(reasons) > 0 && !hasChangelog, reasons
+	if hasChangelog {
+		return false, nil, nil
+	}
+	filtered, err := filterDependencyOnlyPackageJSONReason(cfg, reasons)
+	if err != nil {
+		return false, nil, err
+	}
+	return len(filtered) > 0, filtered, nil
+}
+
+func filterDependencyOnlyPackageJSONReason(cfg config, reasons []string) ([]string, error) {
+	if !contains(reasons, "editors/vscode/package.json") {
+		return reasons, nil
+	}
+	if strings.TrimSpace(cfg.Base) == "" || strings.TrimSpace(cfg.Head) == "" {
+		return reasons, nil
+	}
+	requires, err := vscodePackageChangeRequiresChangelog(cfg.Base, cfg.Head)
+	if err != nil {
+		return nil, err
+	}
+	if requires {
+		return reasons, nil
+	}
+	return without(reasons, "editors/vscode/package.json"), nil
 }
 
 func requiresChangelogForFile(path string) bool {
@@ -107,4 +146,68 @@ func requiresChangelogForFile(path string) bool {
 	default:
 		return false
 	}
+}
+
+func vscodePackageChangeRequiresChangelog(base, head string) (bool, error) {
+	if !commitSHAPattern.MatchString(base) {
+		return false, fmt.Errorf("base ref must be a full commit SHA, got %q", base)
+	}
+	if !commitSHAPattern.MatchString(head) {
+		return false, fmt.Errorf("head ref must be a full commit SHA, got %q", head)
+	}
+	before, err := gitShow(base, "editors/vscode/package.json")
+	if err != nil {
+		return false, fmt.Errorf("read editors/vscode/package.json at %s: %w", base, err)
+	}
+	after, err := gitShow(head, "editors/vscode/package.json")
+	if err != nil {
+		return false, fmt.Errorf("read editors/vscode/package.json at %s: %w", head, err)
+	}
+	return manifestChangeRequiresChangelog(before, after)
+}
+
+func gitShow(ref, path string) ([]byte, error) {
+	// #nosec G204 -- ref is validated as a full commit SHA and path is a constant repo path.
+	cmd := exec.CommandContext(context.Background(), "git", "show", ref+":"+path)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func manifestChangeRequiresChangelog(before, after []byte) (bool, error) {
+	beforeManifest, err := manifestWithoutDependencies(before)
+	if err != nil {
+		return false, err
+	}
+	afterManifest, err := manifestWithoutDependencies(after)
+	if err != nil {
+		return false, err
+	}
+	return !reflect.DeepEqual(beforeManifest, afterManifest), nil
+}
+
+func manifestWithoutDependencies(src []byte) (map[string]any, error) {
+	var manifest map[string]any
+	if err := json.Unmarshal(src, &manifest); err != nil {
+		return nil, fmt.Errorf("parse package.json: %w", err)
+	}
+	delete(manifest, "dependencies")
+	delete(manifest, "devDependencies")
+	return manifest, nil
+}
+
+func contains(items []string, needle string) bool {
+	return slices.Contains(items, needle)
+}
+
+func without(items []string, needle string) []string {
+	filtered := make([]string, 0, len(items))
+	for _, item := range items {
+		if item != needle {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
 }

--- a/scripts/check-vscode-changelog/main_test.go
+++ b/scripts/check-vscode-changelog/main_test.go
@@ -3,10 +3,13 @@ package main
 import "testing"
 
 func TestChangelogRequiredForExtensionUserVisibleChanges(t *testing.T) {
-	required, reasons := changelogRequired([]string{
+	required, reasons, err := changelogRequired(config{}, []string{
 		"editors/vscode/src/extension.ts",
 		"internal/lsp/server.go",
 	})
+	if err != nil {
+		t.Fatalf("changelogRequired error: %v", err)
+	}
 	if !required {
 		t.Fatal("expected changelog to be required")
 	}
@@ -16,22 +19,52 @@ func TestChangelogRequiredForExtensionUserVisibleChanges(t *testing.T) {
 }
 
 func TestChangelogNotRequiredWhenChangelogChanged(t *testing.T) {
-	required, _ := changelogRequired([]string{
+	required, _, err := changelogRequired(config{}, []string{
 		"editors/vscode/src/extension.ts",
 		"editors/vscode/CHANGELOG.md",
 	})
+	if err != nil {
+		t.Fatalf("changelogRequired error: %v", err)
+	}
 	if required {
 		t.Fatal("expected changelog requirement to be satisfied")
 	}
 }
 
 func TestChangelogNotRequiredForIgnoredFiles(t *testing.T) {
-	required, reasons := changelogRequired([]string{
+	required, reasons, err := changelogRequired(config{}, []string{
 		"editors/vscode/scripts/test-extension-smoke.mjs",
 		"editors/vscode/package-lock.json",
 		"internal/lsp/server_test.go",
 	})
+	if err != nil {
+		t.Fatalf("changelogRequired error: %v", err)
+	}
 	if required {
 		t.Fatalf("expected no changelog requirement, got reasons: %v", reasons)
+	}
+}
+
+func TestManifestChangeRequiresChangelogForNonDependencyChange(t *testing.T) {
+	before := []byte(`{"name":"x","engines":{"vscode":"^1.90.0"},"devDependencies":{"@types/vscode":"^1.90.0"}}`)
+	after := []byte(`{"name":"x","engines":{"vscode":"^1.91.0"},"devDependencies":{"@types/vscode":"^1.91.0"}}`)
+	required, err := manifestChangeRequiresChangelog(before, after)
+	if err != nil {
+		t.Fatalf("manifestChangeRequiresChangelog error: %v", err)
+	}
+	if !required {
+		t.Fatal("expected changelog to be required for engine change")
+	}
+}
+
+func TestManifestChangeDoesNotRequireChangelogForDependencyOnlyChange(t *testing.T) {
+	before := []byte(`{"name":"x","engines":{"vscode":"^1.90.0"},"devDependencies":{"@types/vscode":"^1.90.0","esbuild":"^0.27.3"}}`)
+	after := []byte(`{"name":"x","engines":{"vscode":"^1.90.0"},"devDependencies":{"@types/vscode":"^1.90.0","esbuild":"^0.27.4"}}`)
+	required, err := manifestChangeRequiresChangelog(before, after)
+	if err != nil {
+		t.Fatalf("manifestChangeRequiresChangelog error: %v", err)
+	}
+	if required {
+		t.Fatal("expected dependency-only change to skip changelog requirement")
 	}
 }


### PR DESCRIPTION
## Summary
- stop grouping Dependabot updates so each dependency gets its own PR
- ignore `@types/vscode` minor and major bumps while `engines.vscode` stays at `^1.90.0`
- relax the VS Code changelog gate for dependency-only `package.json` changes

## Why
PR #16 fails for two different reasons:
- `editors/vscode/package.json` dependency-only changes were incorrectly treated as changelog-worthy
- `@types/vscode` was bumped past the extension engine floor, which makes `vsce package` fail

## Verification
- `go test ./scripts/check-vscode-changelog`
- `mise run ci`
- replayed the changelog checker against PR #16 base/head SHAs; it now passes, leaving only the real `@types/vscode` packaging incompatibility
