### PR TITLE
fix(lsp): stop scheduling workspace lint during shutdown

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoided a `thriftls` shutdown race that could interrupt workspace diagnostics during extension use.
+
 
 ## [v0.2.1] - 2026-03-14
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -54,6 +54,7 @@ type Server struct {
 	workspaceDiscoveryQueued  bool
 	workspaceDiscoveryReason  index.RebuildReason
 	workspaceLintMu           sync.Mutex
+	workspaceLintShuttingDown bool
 	workspaceLintJobs         map[string]lintJobState
 	workspaceLintWG           sync.WaitGroup
 
@@ -137,7 +138,7 @@ func (s *Server) Run(ctx context.Context, in io.Reader, out io.Writer) error {
 	defer func() {
 		s.cancelAllLintJobs()
 		s.lintWG.Wait()
-		s.cancelAllWorkspaceLintJobs()
+		s.beginWorkspaceLintShutdown()
 		s.workspaceLintWG.Wait()
 		s.closeWorkspaceManager()
 		s.detachRuntime()
@@ -1207,6 +1208,10 @@ func (s *Server) attachRuntime(ctx context.Context, out io.Writer) {
 	s.runCtx = ctx
 	s.output = out
 	s.mu.Unlock()
+
+	s.workspaceLintMu.Lock()
+	s.workspaceLintShuttingDown = false
+	s.workspaceLintMu.Unlock()
 }
 
 func (s *Server) detachRuntime() {
@@ -1350,6 +1355,11 @@ func (s *Server) scheduleWorkspaceLintPublishForURI(uri string) {
 	ctx, cancel := context.WithCancel(runCtx)
 
 	s.workspaceLintMu.Lock()
+	if s.workspaceLintShuttingDown {
+		s.workspaceLintMu.Unlock()
+		cancel()
+		return
+	}
 	if state := s.workspaceLintJobs[canonicalURI]; state.cancel != nil {
 		state.cancel()
 	}
@@ -1616,7 +1626,7 @@ func (s *Server) cancelAllLintJobs() {
 	clear(s.lintJobs)
 }
 
-func (s *Server) cancelAllWorkspaceLintJobs() {
+func (s *Server) beginWorkspaceLintShutdown() {
 	if s == nil {
 		return
 	}
@@ -1624,6 +1634,7 @@ func (s *Server) cancelAllWorkspaceLintJobs() {
 	s.workspaceLintMu.Lock()
 	defer s.workspaceLintMu.Unlock()
 
+	s.workspaceLintShuttingDown = true
 	for _, state := range s.workspaceLintJobs {
 		if state.cancel != nil {
 			state.cancel()

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -592,6 +592,59 @@ func TestServerRunSuppressesStaleDebouncedLintDiagnostics(t *testing.T) {
 	}
 }
 
+func TestServerBeginWorkspaceLintShutdownPreventsNewJobs(t *testing.T) {
+	t.Parallel()
+
+	s := NewServer()
+	s.setLintDebounceForTesting(time.Hour)
+
+	uri := "file:///workspace-shutdown.thrift"
+	if _, err := s.store.Open(context.Background(), uri, 1, []byte("struct S {\n  1: string name,\n}\n")); err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+
+	s.attachRuntime(t.Context(), io.Discard)
+	defer s.detachRuntime()
+
+	s.scheduleWorkspaceLintPublishForURI(uri)
+
+	s.workspaceLintMu.Lock()
+	if got := len(s.workspaceLintJobs); got != 1 {
+		s.workspaceLintMu.Unlock()
+		t.Fatalf("workspaceLintJobs=%d, want 1", got)
+	}
+	if s.workspaceLintShuttingDown {
+		s.workspaceLintMu.Unlock()
+		t.Fatal("workspace lint shutdown should be false before teardown")
+	}
+	s.workspaceLintMu.Unlock()
+
+	s.beginWorkspaceLintShutdown()
+
+	waitDone := make(chan struct{})
+	go func() {
+		s.workspaceLintWG.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+	case <-time.After(time.Second):
+		t.Fatal("workspace lint jobs did not stop after shutdown")
+	}
+
+	s.scheduleWorkspaceLintPublishForURI(uri)
+
+	s.workspaceLintMu.Lock()
+	defer s.workspaceLintMu.Unlock()
+	if !s.workspaceLintShuttingDown {
+		t.Fatal("workspace lint shutdown should remain enabled during teardown")
+	}
+	if got := len(s.workspaceLintJobs); got != 0 {
+		t.Fatalf("workspaceLintJobs=%d, want 0 after shutdown", got)
+	}
+}
+
 func TestServerRunPublishesCurrentParserDiagnosticsOnDidChangeFailure(t *testing.T) {
 	restoreBreaker := syntax.ResetBackendBreakerForTesting()
 	defer restoreBreaker()


### PR DESCRIPTION
## Summary
- stop scheduling new workspace-lint jobs once server teardown starts
- cancel in-flight workspace-lint jobs before waiting on the workspace-lint waitgroup
- add a regression test for the shutdown gate

## Why
The `race-lsp` job in release PR #19 found a real race in `internal/lsp.Server.Run` teardown. Workspace discovery could still enqueue new workspace-lint jobs while `Run` was already waiting on `workspaceLintWG`, which triggered both:
- a data race on the waitgroup
- `panic: sync: WaitGroup is reused before previous Wait has returned`

## Verification
- `CGO_ENABLED=1 go test -race ./internal/lsp -run TestServerRunNavigationQueriesReturnEmptyForUnresolvedBinding -count=5`
- `mise run test-race-lsp`
- `mise run ci`
