### PR TITLE
ci: Harden GitHub Actions with pedantic zizmor and hook coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
     commit-message:
@@ -21,6 +23,8 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
     commit-message:
@@ -34,6 +38,8 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "America/New_York"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
     commit-message:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,46 +7,73 @@ on:
   pull_request:
 
 permissions:
-  actions: write
   contents: read
 
 env:
   CGO_ENABLED: "0"
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
+        with:
+          advanced-security: false
+          annotations: true
+          inputs: .github/workflows .github/dependabot.yml
+          persona: pedantic
+          version: 1.24.1
+
   vscode-changelog-policy:
     name: vscode-changelog-policy
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./go.mod
 
       - name: Check VS Code changelog policy
         run: |
           mkdir -p .tmp
-          git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" > .tmp/changed-files.txt
+          git diff --name-only "${BASE_SHA}...${HEAD_SHA}" > .tmp/changed-files.txt
           go run ./scripts/check-vscode-changelog \
             --file-list .tmp/changed-files.txt \
-            --base "${{ github.event.pull_request.base.sha }}" \
-            --head "${{ github.event.pull_request.head.sha }}"
+            --base "${BASE_SHA}" \
+            --head "${HEAD_SHA}"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
   lint-and-test:
     name: lint-and-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: Install pinned tools
         run: mise install
@@ -68,10 +95,12 @@ jobs:
           - windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./go.mod
 
@@ -85,10 +114,12 @@ jobs:
       CGO_ENABLED: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: Install pinned tools
         run: mise install
@@ -101,10 +132,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
 
@@ -115,7 +148,7 @@ jobs:
           npm --prefix editors/vscode run package -- --no-yarn --allow-missing-repository
 
       - name: Upload VSIX artifact for release smoke
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7
         with:
           name: vscode-vsix-smoke
           path: editors/vscode/*.vsix
@@ -133,15 +166,17 @@ jobs:
           - windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./go.mod
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
 
@@ -157,18 +192,19 @@ jobs:
     needs: package-vscode-extension-smoke
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: Install pinned tools
         run: mise install
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v8
         with:
           name: vscode-vsix-smoke
           path: .release-extra
@@ -195,7 +231,7 @@ jobs:
             --checksums dist/checksums.txt \
             --output dist/thriftls-manifest.json
 
-          vsix_path="$(ls .release-extra/*.vsix | head -n1)"
+          vsix_path="$(find .release-extra -maxdepth 1 -name '*.vsix' -print -quit)"
           go run ./scripts/generate-vscode-release-metadata \
             --vsix "$vsix_path" \
             --checksums dist/checksums.txt \
@@ -216,7 +252,7 @@ jobs:
           test -s dist/sbom.cdx.json
 
       - name: Upload release integrity artifacts (smoke)
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7
         with:
           name: release-integrity-smoke
           path: |
@@ -231,17 +267,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: Install pinned tools
         run: mise install
 
       - name: Restore previous perf state
         if: github.event_name == 'push'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .tmp/perf-gate-state.env
           key: perf-gate-${{ github.ref_name }}-${{ github.run_id }}
@@ -292,11 +330,13 @@ jobs:
         shell: bash
         run: |
           mkdir -p .tmp
-          printf 'PERF_GATE_BREACH=%s\n' "${{ steps.current-perf.outputs.current-breach }}" > .tmp/perf-gate-state.env
+          printf 'PERF_GATE_BREACH=%s\n' "${STEPS_CURRENT_PERF_OUTPUTS_CURRENT_BREACH}" > .tmp/perf-gate-state.env
+        env:
+          STEPS_CURRENT_PERF_OUTPUTS_CURRENT_BREACH: ${{ steps.current-perf.outputs.current-breach }}
 
       - name: Save current perf state
         if: github.event_name == 'push' && always()
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .tmp/perf-gate-state.env
           key: perf-gate-${{ github.ref_name }}-${{ github.run_id }}
@@ -304,14 +344,19 @@ jobs:
       - name: Enforce perf policy
         run: |
           go run ./scripts/evaluate-perf-policy \
-            --event-name "${{ github.event_name }}" \
-            --current-breach="${{ steps.current-perf.outputs.current-breach }}" \
-            --previous-known="${{ steps.previous-perf.outputs.previous-known }}" \
-            --previous-breach="${{ steps.previous-perf.outputs.previous-breach }}"
+            --event-name "${GITHUB_EVENT_NAME}" \
+            --current-breach="${STEPS_CURRENT_PERF_OUTPUTS_CURRENT_BREACH}" \
+            --previous-known="${STEPS_PREVIOUS_PERF_OUTPUTS_PREVIOUS_KNOWN}" \
+            --previous-breach="${STEPS_PREVIOUS_PERF_OUTPUTS_PREVIOUS_BREACH}"
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          STEPS_CURRENT_PERF_OUTPUTS_CURRENT_BREACH: ${{ steps.current-perf.outputs.current-breach }}
+          STEPS_PREVIOUS_PERF_OUTPUTS_PREVIOUS_KNOWN: ${{ steps.previous-perf.outputs.previous-known }}
+          STEPS_PREVIOUS_PERF_OUTPUTS_PREVIOUS_BREACH: ${{ steps.previous-perf.outputs.previous-breach }}
 
       - name: Upload perf gate report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7
         with:
           name: perf-gate-report
           path: .tmp/perf-report.json
@@ -322,10 +367,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: Install pinned tools
         run: mise install
@@ -342,10 +389,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: Install pinned tools
         run: mise install
@@ -369,10 +418,12 @@ jobs:
       THRIFT_ORACLE_VERSION_PREFIX: ${{ vars.THRIFT_ORACLE_VERSION_PREFIX }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: Install pinned tools
         run: mise install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           npm --prefix editors/vscode run package -- --no-yarn --allow-missing-repository
 
       - name: Upload VSIX artifact for release smoke
-        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: vscode-vsix-smoke
           path: editors/vscode/*.vsix
@@ -204,7 +204,7 @@ jobs:
         run: mise install
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: vscode-vsix-smoke
           path: .release-extra
@@ -252,7 +252,7 @@ jobs:
           test -s dist/sbom.cdx.json
 
       - name: Upload release integrity artifacts (smoke)
-        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-integrity-smoke
           path: |
@@ -356,7 +356,7 @@ jobs:
 
       - name: Upload perf gate report
         if: always()
-        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: perf-gate-report
           path: .tmp/perf-report.json

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -44,10 +44,12 @@ jobs:
             target: FuzzDocumentAndRange
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: Install pinned tools
         run: mise install
@@ -60,12 +62,12 @@ jobs:
 
           profile="daily"
           fuzztime="2m"
-          if [ "${{ github.event_name }}" = "schedule" ] && [ "${{ github.event.schedule }}" = "29 4 * * 0" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ] && [ "${GITHUB_EVENT_SCHEDULE}" = "29 4 * * 0" ]; then
             profile="weekly"
             fuzztime="10m"
           fi
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            profile="${{ inputs.profile }}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            profile="${INPUTS_PROFILE}"
             case "$profile" in
               daily)  fuzztime="2m" ;;
               weekly) fuzztime="10m" ;;
@@ -79,6 +81,10 @@ jobs:
           echo "profile=$profile" >> "$GITHUB_OUTPUT"
           echo "fuzztime=$fuzztime" >> "$GITHUB_OUTPUT"
           echo "Resolved profile=$profile fuzztime=$fuzztime"
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
+          INPUTS_PROFILE: ${{ inputs.profile }}
 
       - name: Run fuzz target
         shell: bash
@@ -86,21 +92,25 @@ jobs:
           set -euo pipefail
 
           mkdir -p "$RUNNER_TEMP/fuzz-logs"
-          log_path="$RUNNER_TEMP/fuzz-logs/${{ matrix.id }}.log"
+          log_path="$RUNNER_TEMP/fuzz-logs/${FUZZ_ID}.log"
 
-          mise exec golang -- go test "${{ matrix.pkg }}" \
+          mise exec golang -- go test "${FUZZ_PKG}" \
             -run='^$' \
-            -fuzz="${{ matrix.target }}" \
-            -fuzztime="${{ steps.profile.outputs.fuzztime }}" \
+            -fuzz="${FUZZ_TARGET}" \
+            -fuzztime="${STEPS_PROFILE_OUTPUTS_FUZZTIME}" \
             2>&1 | tee "$log_path"
+        env:
+          FUZZ_ID: ${{ matrix.id }}
+          FUZZ_PKG: ${{ matrix.pkg }}
+          FUZZ_TARGET: ${{ matrix.target }}
+          STEPS_PROFILE_OUTPUTS_FUZZTIME: ${{ steps.profile.outputs.fuzztime }}
 
       - name: Upload fuzz crashers and logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7
         with:
           name: nightly-fuzz-${{ steps.profile.outputs.profile }}-${{ matrix.id }}-${{ github.run_id }}
           path: |
             internal/**/testdata/fuzz/**
             ${{ runner.temp }}/fuzz-logs/*.log
           if-no-files-found: ignore
-

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload fuzz crashers and logs
         if: always()
-        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nightly-fuzz-${{ steps.profile.outputs.profile }}-${{ matrix.id }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -10,14 +10,20 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+
+concurrency:
+  group: pr-labels-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   label:
+    name: label
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Required by actions/labeler to apply path labels on pull requests.
     steps:
       - name: Apply path labels
-        uses: actions/labeler@v6
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,16 +6,23 @@ on:
       - main
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
+
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release-please:
+    name: release-please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required by release-please to create release commits and tags.
+      issues: write # Required by release-please to update linked release issues.
+      pull-requests: write # Required by release-please to create and update release PRs.
     steps:
       - name: Run release-please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-pr-maintenance.yml
+++ b/.github/workflows/release-pr-maintenance.yml
@@ -9,25 +9,33 @@ on:
       - reopened
 
 permissions:
-  contents: write
-  pull-requests: read
+  contents: read
+
+concurrency:
+  group: release-pr-maintenance-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   rollup-vscode-changelog:
+    name: rollup-vscode-changelog
     if: >-
       startsWith(github.event.pull_request.title, 'chore: release ') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease: pending')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push changelog updates to release PR branches.
+      pull-requests: read # Required to inspect release PR metadata before changelog updates.
     steps:
       - name: Checkout release PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          persist-credentials: true
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm --prefix editors/vscode run package -- --no-yarn --allow-missing-repository
 
       - name: Upload VSIX artifact for GoReleaser release job
-        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: vscode-vsix
           path: editors/vscode/*.vsix
@@ -81,7 +81,7 @@ jobs:
         run: mise install
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: vscode-vsix
           path: .release-extra
@@ -189,7 +189,7 @@ jobs:
           package-manager-cache: false
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: vscode-vsix
           path: .release-extra
@@ -220,7 +220,7 @@ jobs:
           package-manager-cache: false
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: vscode-vsix
           path: .release-extra

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,13 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   CGO_ENABLED: "0"
 
@@ -14,12 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm --prefix editors/vscode ci
@@ -31,7 +41,7 @@ jobs:
         run: npm --prefix editors/vscode run package -- --no-yarn --allow-missing-repository
 
       - name: Upload VSIX artifact for GoReleaser release job
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7
         with:
           name: vscode-vsix
           path: editors/vscode/*.vsix
@@ -46,29 +56,32 @@ jobs:
       run:
         working-directory: ${{ github.workspace }}
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-      id-token: write
-      attestations: write
-      artifact-metadata: write
+      contents: write # Required by GoReleaser and gh release upload to publish release assets.
+      issues: write # Required by GoReleaser release integrations.
+      pull-requests: write # Required by GoReleaser release integrations and release PR comments.
+      id-token: write # Required by artifact provenance attestation.
+      attestations: write # Required by actions/attest-build-provenance.
+      artifact-metadata: write # Required by actions/attest-build-provenance.
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
 
       - name: Install pinned tools
         run: mise install
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v8
         with:
           name: vscode-vsix
           path: .release-extra
@@ -88,7 +101,7 @@ jobs:
 
       - name: Generate VS Code release metadata
         run: |
-          vsix_path="$(ls .release-extra/*.vsix | head -n1)"
+          vsix_path="$(find .release-extra -maxdepth 1 -name '*.vsix' -print -quit)"
           go run ./scripts/generate-vscode-release-metadata \
             --vsix "$vsix_path" \
             --checksums dist/checksums.txt \
@@ -126,7 +139,7 @@ jobs:
             --output dist/release-notes.md
 
       - name: Generate artifact attestations (release artifacts)
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: |
             dist/*.tar.gz
@@ -138,13 +151,12 @@ jobs:
             dist/sbom.cdx.json
 
       - name: Upload manifest + metadata to GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          files: |
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" \
             dist/thriftls-manifest.json
             dist/vscode-release-metadata.json
-            dist/sbom.cdx.json
+            dist/sbom.cdx.json \
+            --clobber
 
       - name: Update GitHub release notes
         run: gh release edit "${GITHUB_REF_NAME}" --notes-file dist/release-notes.md
@@ -171,12 +183,13 @@ jobs:
     environment: release
     steps:
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
+          package-manager-cache: false
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v8
         with:
           name: vscode-vsix
           path: .release-extra
@@ -185,7 +198,7 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
-          vsix_path="$(ls .release-extra/*.vsix | head -n1)"
+          vsix_path="$(find .release-extra -maxdepth 1 -name '*.vsix' -print -quit)"
           if [ -z "$vsix_path" ]; then
             echo "VSIX artifact not found" >&2
             exit 1
@@ -201,12 +214,13 @@ jobs:
     environment: release
     steps:
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
+          package-manager-cache: false
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v8
         with:
           name: vscode-vsix
           path: .release-extra
@@ -215,7 +229,7 @@ jobs:
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
-          vsix_path="$(ls .release-extra/*.vsix | head -n1)"
+          vsix_path="$(find .release-extra -maxdepth 1 -name '*.vsix' -print -quit)"
           if [ -z "$vsix_path" ]; then
             echo "VSIX artifact not found" >&2
             exit 1

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -9,15 +9,22 @@ on:
       - reopened
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
+
+concurrency:
+  group: semantic-pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   validate:
+    name: validate
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # Required to sync title-derived issue labels on the PR.
+      pull-requests: write # Required by semantic title validation and PR label sync.
     steps:
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -36,7 +43,7 @@ jobs:
             revert
 
       - name: Sync title-based labels
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      # pull_request_target is intentional here: the workflow never checks out
+      # or executes pull request code, and only applies repository labels.
+      - pr-labels.yml
+      # pull_request_target is intentional here: the workflow is guarded to
+      # same-repository release PRs before checking out and pushing changes.
+      - release-pr-maintenance.yml
+      # pull_request_target is intentional here: the workflow never checks out
+      # or executes pull request code, and only validates metadata/syncs labels.
+      - semantic-pr-title.yml

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -8,6 +8,15 @@ pre-push:
 pre-commit:
   fail_on_changes: "always"
   jobs:
+    - name: github actions lint
+      glob:
+        - ".github/dependabot.yml"
+        - ".github/workflows/**"
+        - ".github/zizmor.yml"
+        - ".lefthook.yml"
+        - "mise.toml"
+      run: mise run actions-lint
+
     - name: generate tree-sitter parser
       glob:
         - "grammar/tree-sitter-thrift/grammar.js"

--- a/docs/wasm-grammar-build.md
+++ b/docs/wasm-grammar-build.md
@@ -7,7 +7,7 @@ This document defines the reproducible grammar artifact pipeline for wasm parser
 Toolchain versions are pinned in [mise.toml](/Users/dmytro/work/github/thrift-weaver/mise.toml):
 
 - `tree-sitter = 0.26.5`
-- `golang = 1.26.1`
+- `golang = 1.26.3`
 - `node = 22.14.0`
 
 `tree-sitter build --wasm` downloads a pinned `wasi-sdk` toolchain on first run (currently `wasi-sdk-29` under `~/.cache/tree-sitter`).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kpumuk/thrift-weaver
 
-go 1.26.1
+go 1.26.3
 
 require github.com/tetratelabs/wazero v1.11.0
 

--- a/mise.toml
+++ b/mise.toml
@@ -5,10 +5,16 @@ tree-sitter = "0.26.5"
 golangci-lint = "2.10.1"
 lefthook = "2.1.1"
 goreleaser = "2.14.0"
+actionlint = "1.7.12"
+zizmor = "1.24.1"
 
 [tasks.ci]
 description = "Run formatter, linters, and tests (Go + VS Code extension)"
 depends = ["format", "lint", "test", "vscode-ci"]
+
+[tasks.actions-lint]
+description = "Lint GitHub Actions workflows and Dependabot configuration"
+run = "actionlint && zizmor --pedantic ."
 
 [tasks.format]
 description = "Format Go code with golangci-lint formatters"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-golang = "1.26.1"
+golang = "1.26.3"
 node = "22.14.0"
 tree-sitter = "0.26.5"
 golangci-lint = "2.10.1"


### PR DESCRIPTION
## Summary
- Add a `zizmor` CI job in pedantic mode and pin the workflow to immutable action SHAs.
- Harden workflows with `persist-credentials: false`, explicit concurrency, narrower permissions, and safer shell env handling.
- Add Dependabot cooldowns and wire GitHub Actions linting into pre-commit via `actionlint` + `zizmor`.
- Update the pinned Go toolchain to `1.26.3` to match the current vulnerability baseline.

## Testing
- `zizmor --pedantic .` passes.
- `actionlint` passes.
- `lefthook run pre-commit` passes for the staged hook/tooling changes.
- `mise run lint` and `mise run vscode-ci` pass.