### PR TITLE
ci: fix release metadata upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,8 +153,8 @@ jobs:
       - name: Upload manifest + metadata to GitHub release
         run: |
           gh release upload "${GITHUB_REF_NAME}" \
-            dist/thriftls-manifest.json
-            dist/vscode-release-metadata.json
+            dist/thriftls-manifest.json \
+            dist/vscode-release-metadata.json \
             dist/sbom.cdx.json \
             --clobber
 


### PR DESCRIPTION
### Why?

The v0.3.1 release pipeline failed after publishing because the metadata upload step did not pass --clobber to the first asset upload.

### How?

Keep the release metadata assets in the same gh release upload invocation so retries overwrite existing assets as intended.

Related run:

- https://github.com/kpumuk/thrift-weaver/actions/runs/25638098134/job/75253827542