### PR TITLE
fix: tolerate non-release PR tags in release notes

### DIFF
--- a/scripts/compose-release-notes/main.go
+++ b/scripts/compose-release-notes/main.go
@@ -34,6 +34,7 @@ type pullRequest struct {
 	Number   int        `json:"number"`
 	Title    string     `json:"title"`
 	Body     string     `json:"body"`
+	URL      string     `json:"html_url"`
 	MergedAt *time.Time `json:"merged_at"`
 }
 
@@ -250,5 +251,23 @@ func (g githubClient) fetchReleasePRBody(ctx context.Context, repo, commit strin
 			return strings.TrimSpace(pr.Body), nil
 		}
 	}
-	return "", errors.New("release pull request not found for tagged commit")
+	return renderAssociatedPRNotes(repo, pulls)
+}
+
+func renderAssociatedPRNotes(repo string, pulls []pullRequest) (string, error) {
+	var lines []string
+	for _, pr := range pulls {
+		if pr.MergedAt == nil {
+			continue
+		}
+		url := pr.URL
+		if url == "" {
+			url = fmt.Sprintf("https://github.com/%s/pull/%d", repo, pr.Number)
+		}
+		lines = append(lines, fmt.Sprintf("- %s ([#%d](%s))", pr.Title, pr.Number, url))
+	}
+	if len(lines) == 0 {
+		return "", errors.New("release pull request not found for tagged commit")
+	}
+	return "## Changes\n\n" + strings.Join(lines, "\n"), nil
 }

--- a/scripts/compose-release-notes/main_test.go
+++ b/scripts/compose-release-notes/main_test.go
@@ -99,6 +99,32 @@ func TestFetchReleasePRBody(t *testing.T) {
 	}
 }
 
+func TestFetchReleasePRBodyFallsBackToAssociatedPRSummary(t *testing.T) {
+	mergedAt := time.Now().UTC().Format(time.RFC3339)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/kpumuk/thrift-weaver/commits/def456/pulls" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`[{"number":43,"title":"ci: fix release metadata upload","body":"ignored","html_url":"https://github.com/kpumuk/thrift-weaver/pull/43","merged_at":"` + mergedAt + `"}]`))
+	}))
+	defer server.Close()
+
+	client := githubClient{
+		baseURL: server.URL,
+		token:   "test-token",
+		client:  server.Client(),
+	}
+	got, err := client.fetchReleasePRBody(context.Background(), "kpumuk/thrift-weaver", "def456")
+	if err != nil {
+		t.Fatalf("fetchReleasePRBody error: %v", err)
+	}
+	want := "## Changes\n\n- ci: fix release metadata upload ([#43](https://github.com/kpumuk/thrift-weaver/pull/43))"
+	if got != want {
+		t.Fatalf("body=%q want %q", got, want)
+	}
+}
+
 func TestComposeReleaseNotes(t *testing.T) {
 	perfJSON, err := os.ReadFile("testdata/perf.json")
 	if err != nil {


### PR DESCRIPTION
### Why?

The v0.3.2 release pipeline failed because the tagged commit was a normal merged PR, not a release-please PR, and the release-notes script treated that as fatal.

### How?

Keep using release-please PR bodies when present, and fall back to a generated Changes section from associated merged PRs for hotfix-style release tags.

Related run:

- https://github.com/kpumuk/thrift-weaver/actions/runs/25638798041/job/75255439920